### PR TITLE
修正因接口更新导致表情不能复制的问题

### DIFF
--- a/src/HM.lua
+++ b/src/HM.lua
@@ -215,7 +215,7 @@ _HM.ParseFaceIcon = function(t)
 		_HM.tFaceIcon = {}
 		for i = 1, g_tTable.FaceIcon:GetRowCount() do
 			local tLine = g_tTable.FaceIcon:GetRow(i)
-			_HM.tFaceIcon[tLine.szCommand] = true
+			_HM.tFaceIcon[tLine.szCommand] = tLine.dwID
 		end
 	end
 	local t2 = {}
@@ -228,7 +228,7 @@ _HM.ParseFaceIcon = function(t)
 		else
 			local nOff, nLen = 1, string.len(v.text)
 			while nOff <= nLen do
-				local szFace = nil
+				local szFace, dwFaceID = nil, nil
 				local nPos = StringFindW(v.text, "#", nOff)
 				if not nPos then
 					nPos = nLen
@@ -237,7 +237,7 @@ _HM.ParseFaceIcon = function(t)
 						if i <= nLen then
 							local szTest = string.sub(v.text, nPos, i)
 							if _HM.tFaceIcon[szTest] then
-								szFace = szTest
+								szFace, dwFaceID = szTest, _HM.tFaceIcon[szTest]
 								nPos = nPos - 1
 								break
 							end
@@ -248,8 +248,8 @@ _HM.ParseFaceIcon = function(t)
 					table.insert(t2, { type = "text", text = string.sub(v.text, nOff, nPos) })
 					nOff = nPos + 1
 				end
-				if szFace then
-					table.insert(t2, { type = "text", text = szFace })
+				if szFace and dwFaceID then
+					table.insert(t2, { type = "emotion", text = szFace, id = dwFaceID })
 					nOff = nOff + string.len(szFace)
 				end
 			end

--- a/src/HM_ToolBox.lua
+++ b/src/HM_ToolBox.lua
@@ -644,9 +644,9 @@ _HM_ToolBox.InitFaceIcon = function()
 		for i = 1, g_tTable.FaceIcon:GetRowCount() do
 			local tLine = g_tTable.FaceIcon:GetRow(i)
 			if tLine.szType == "animate" then
-				t.animate[tLine.nFrame] = tLine.szCommand
+				t.animate[tLine.nFrame] = { szCmd = tLine.szCommand, dwID = tLine.dwID }
 			else
-				t.image[tLine.nFrame] = tLine.szCommand
+				t.image[tLine.nFrame] = { szCmd = tLine.szCommand, dwID = tLine.dwID }
 			end
 		end
 		_HM_ToolBox.tFacIcon = t
@@ -727,22 +727,24 @@ _HM_ToolBox.CopyChatLine = function(hTime)
 			end
 		elseif p:GetType() == "Image" then
 			local nFrame = p:GetFrame()
-			local szCmd = _HM_ToolBox.tFacIcon.image[nFrame]
-			if szCmd then
+			local tEmotion = _HM_ToolBox.tFacIcon.image[nFrame]
+			if tEmotion then
+				local szCmd, dwFaceID = tEmotion.szCmd, tEmotion.dwID
 				if string.byte(szCmd, 2, 2) < 128 then
 					szCmd = string.sub(szCmd, 1, 1) .. string.sub(szCmd, 3)
 				end
-				edit:InsertObj(szCmd, { type = "text", text = szCmd })
+				edit:InsertObj(szCmd, { type = "emotion", text = szCmd, id = dwFaceID })
 			end
 		elseif p:GetType() == "Animate" then
 			local nGroup = tonumber(p:GetName())
 			if nGroup then
-				local szCmd = _HM_ToolBox.tFacIcon.animate[nGroup]
-				if szCmd then
+				local tEmotion = _HM_ToolBox.tFacIcon.animate[nGroup]
+				if tEmotion then
+					local szCmd, dwFaceID = tEmotion.szCmd, tEmotion.dwID
 					if string.byte(szCmd, 2, 2) < 128 then
 						szCmd = string.sub(szCmd, 1, 1) .. string.sub(szCmd, 3)
 					end
-					edit:InsertObj(szCmd, { type = "text", text = szCmd })
+					edit:InsertObj(szCmd, { type = "emotion", text = szCmd, id = dwFaceID })
 				end
 			end
 		end


### PR DESCRIPTION
### 修正因接口更新导致表情不能复制的问题
- 文件`HM.lua`：修正`_HM.ParseFaceIcon(tSay)`
- 文件`HM_ToolBox.lua`：修正复制行函数`_HM_ToolBox.CopyChatLine(hTime)` 与`_HM_ToolBox.InitFaceIcon()`表情数组缓存初始化函数
##### By [`茗伊@双梦镇@荻花宫`](http://weibo.com/zymah) at 20140425
